### PR TITLE
Equipping

### DIFF
--- a/Scenes/Entities/Scripts/entity_state.gd
+++ b/Scenes/Entities/Scripts/entity_state.gd
@@ -1,5 +1,5 @@
 class_name EntityState extends State
 
-var actor: CharacterBody2D #Auto assign parent entity to each state
+var actor: CharacterBody2D
 var movement_manager: Movement
 var animations: AnimatedSprite2D

--- a/Scenes/Entities/Scripts/entity_state.gd
+++ b/Scenes/Entities/Scripts/entity_state.gd
@@ -2,3 +2,4 @@ class_name EntityState extends State
 
 var actor: CharacterBody2D #Auto assign parent entity to each state
 var movement_manager: Movement
+var animations: AnimatedSprite2D

--- a/Scenes/Entities/Scripts/movement_manager.gd
+++ b/Scenes/Entities/Scripts/movement_manager.gd
@@ -2,7 +2,7 @@ class_name Movement
 extends Node
 
 @export var actor: CharacterBody2D
-@export var input_manager: InputManager
+@export var input_manager: LogicManager
 
 @export var MAX_SPEED: int = 100
 @export var walk_speed: int = 80

--- a/Scenes/Entities/player/player_state_machine.gd
+++ b/Scenes/Entities/player/player_state_machine.gd
@@ -10,4 +10,3 @@ func _ready():
 		states[state].actor = actor
 		states[state].movement_manager = player_movement
 		states[state].input_manager = player_input
-		print(state)

--- a/Scenes/Entities/player/player_state_machine.gd
+++ b/Scenes/Entities/player/player_state_machine.gd
@@ -1,3 +1,13 @@
 class_name PlayerStateMachine extends StateMachine
 
-## StateMachine Version 2
+@export var actor: Player
+@export var player_movement: Movement
+@export var player_input: InputManager
+
+func _ready():
+	super()
+	for state in states:
+		states[state].actor = actor
+		states[state].movement_manager = player_movement
+		states[state].input_manager = player_input
+		print(state)

--- a/utilities/state_class.gd
+++ b/utilities/state_class.gd
@@ -3,7 +3,6 @@ class_name State extends Node
 var active: bool = false
 
 var state_machine: StateMachine
-var animations: AnimatedSprite2D
 var state_path: Array
 
 func enter() -> void:
@@ -44,4 +43,3 @@ func get_all_child_states(states:Dictionary, state_machine):
 func create_path_list(state: State): # generates paths from state_machine to a state
 	var node_path: NodePath = state_machine.get_path_to(state)
 	state_path = node_path.get_concatenated_names().split("/")
-	#print(state, state_path)

--- a/utilities/state_class.gd
+++ b/utilities/state_class.gd
@@ -27,11 +27,8 @@ func switch_cond() -> bool:
 func default_switch(): # check if there's a default substate to switch to
 	return false # doesn't work properly
 
-func get_all_child_states(states:Dictionary, actor, state_machine, movement_manager, input_manager):
-	self.actor = actor
+func get_all_child_states(states:Dictionary, state_machine):
 	self.state_machine = state_machine
-	self.movement_manager = movement_manager
-	self.input_manager = input_manager
 	states[self.name] = self
 	
 	create_path_list(self)
@@ -40,7 +37,7 @@ func get_all_child_states(states:Dictionary, actor, state_machine, movement_mana
 	if children.size() > 0: # checks if the current state has children states
 		for child in children:
 			if child is State:
-				child.get_all_child_states(states, actor, state_machine, movement_manager, input_manager)
+				child.get_all_child_states(states, state_machine)
 	else:
 		return
 

--- a/utilities/state_machine.gd
+++ b/utilities/state_machine.gd
@@ -14,23 +14,22 @@ func _ready():
 
 
 func change_state(state_name: StringName) -> void:
-	if state_name and states.has(state_name): #if the state_name is valid
+	if current_state and state_name and states.has(state_name): #if the state_name is valid
 		new_state = states[state_name]
-		if current_state: # if we're currently in a valid state
-			var pointer: Node = current_state
+		var pointer: Node = current_state
 			
-			for path_step in find_route(current_state, new_state):
-				if pointer.get_node(path_step) != null:
-					pointer = pointer.get_node(path_step)
-					if path_step == "..":
-						current_state.exit()
-						current_state.active = false
-						if pointer is State:
-							current_state = pointer
-					else:
+		for path_step in find_route(current_state, new_state):
+			if pointer.get_node(path_step) != null:
+				pointer = pointer.get_node(path_step)
+				if path_step == "..":
+					current_state.exit()
+					current_state.active = false
+					if pointer is State:
 						current_state = pointer
-						current_state.enter()
-						current_state.active = true
+				else:
+					current_state = pointer
+					current_state.enter()
+					current_state.active = true
 
 
 func check_switch(state):

--- a/utilities/state_machine.gd
+++ b/utilities/state_machine.gd
@@ -18,18 +18,24 @@ func change_state(state_name: StringName) -> void:
 		new_state = states[state_name]
 		var pointer: Node = current_state
 			
-		for path_step in find_route(current_state, new_state):
-			if pointer.get_node(path_step) != null:
-				pointer = pointer.get_node(path_step)
-				if path_step == "..":
-					current_state.exit()
-					current_state.active = false
+		for path_step in find_route(current_state, new_state): # for each step in the path
+			if pointer.get_node(path_step) != null: # check if it's valid
+				pointer = pointer.get_node(path_step) # increment
+				
+				# Moving UP the state tree
+				if path_step == "..": # if you're moving up the tree
+					current_state.exit() # exit the state you're in
+					current_state.active = false # set it as inactive
 					if pointer is State:
 						current_state = pointer
+				
+				 # Moving DOWN the state tree
 				else:
 					current_state = pointer
 					current_state.enter()
 					current_state.active = true
+				
+				#continue looping
 
 
 func check_switch(state):

--- a/utilities/state_machine.gd
+++ b/utilities/state_machine.gd
@@ -63,13 +63,11 @@ func run_state(state: State, physics, delta):
 func _physics_process(delta):
 	if current_state:
 		run_state(current_state, true, delta)
-		#current_state.physics_update(delta)
 		check_switch(current_state)
 
 
 func _process(delta):
 	if current_state:
-		#current_state.update(delta)
 		run_state(current_state, false, delta)
 
 

--- a/utilities/state_machine.gd
+++ b/utilities/state_machine.gd
@@ -1,8 +1,5 @@
 class_name StateMachine extends Node
 
-@export var actor: CharacterBody2D
-@export var player_movement: Movement
-@export var player_input: InputManager
 @export var initial_state: State
 
 var current_state: State
@@ -81,4 +78,6 @@ func store_all_states():
 ## States can be called later by name to get specific state
 	for child in get_children():
 		if child is State: #and child.is_active:
-			child.get_all_child_states(states, actor, self, player_movement, player_input)
+			# passing reference to the states dictionary and state machine (self)
+			# this is bare minimum required for anything that will use states/statemachines
+			child.get_all_child_states(states, self)


### PR DESCRIPTION
It might be worth separating the following code out and creating two functions, one that traverses DOWN the state tree and another that traverses UP. That way the code is a bit more clean, reduces the amount of indentation and it can be repurposed for other functions. E.g. the `check_switch(state)` function travels up the tree as well.
```	
		# Moving UP the state tree
		if path_step == "..": # if you're moving up the tree
			current_state.exit() # exit the state you're in
			current_state.active = false # set it as inactive
			if pointer is State:
				current_state = pointer
		
			# Moving DOWN the state tree
		else:
			current_state = pointer
			current_state.enter()
			current_state.active = true
		
		#continue looping
```

State machine code is a lot cleaner and looks like it could be used for other things e.g. entities or even the game itself (for something like loading game state, saving game state, transition game state). Going to look into flushing out the movement script next. Again, lots of player specific code is in there (direct reference to the input manager needs to be taken out).